### PR TITLE
adjustable is_ros2 property

### DIFF
--- a/xarm_description/urdf/_private_macro.xacro
+++ b/xarm_description/urdf/_private_macro.xacro
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="private_macro">
   
-  <xacro:property name="is_ros2" value="true" scope="parent"/>
+  <xacro:property name="is_ros2" default="true"/>
   <xacro:property name="use_xacro_load_yaml" value="true" scope="parent"/>
   <xacro:property name="use_len" value="true" scope="parent"/>
 

--- a/xarm_description/urdf/gripper/xarm_gripper_macro.xacro
+++ b/xarm_description/urdf/gripper/xarm_gripper_macro.xacro
@@ -20,9 +20,9 @@
 
     <xacro:xarm_gripper_gazebo prefix="${prefix}" />
 
-    <xacro:if value="${not is_ros2}">
-      <xacro:xarm_gazebo_grasp_fix prefix="${prefix}" palm_link="${prefix}link${dof}" />
-    </xacro:if>
+    <!--<xacro:if value="${not is_ros2}">-->
+    <!--  <xacro:xarm_gazebo_grasp_fix prefix="${prefix}" palm_link="${prefix}link${dof}" />-->
+    <!--</xacro:if>-->
 
     <!-- mimic_joint_plugin has to be installed: -->
     <!--<xacro:mimic_joint_plugin_gazebo name_prefix="${prefix}left_finger_joint"-->


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #7 

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
adding the following xacro:arg property will override it
```
<xacro:property name="is_ros2" value="false"/>
```

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
