### PR TITLE
Fix out of range bug

### DIFF
--- a/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
+++ b/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
@@ -269,17 +269,25 @@ namespace uf_robot_hardware
         for (uint i = 0; i < position_states_.size(); i++) {
             if (std::isnan(position_states_[i])) {
                 position_states_[i] = 0;
-                position_cmds_[i] = 0;
+                if (i < position_cmds_.size()) {
+                    position_cmds_[i] = 0;
+                }
             } else {
-                position_cmds_[i] = position_states_[i];
+                if (i < position_cmds_.size()) {
+                    position_cmds_[i] = position_states_[i];
+                }
             }
         }
         for (uint i = 0; i < velocity_states_.size(); i++) {
             if (std::isnan(velocity_states_[i])) {
                 velocity_states_[i] = 0;
-                velocity_cmds_[i] = 0;
+                if (i < velocity_cmds_.size()) {
+                    velocity_cmds_[i] = 0;
+                }
             } else {
-                velocity_cmds_[i] = velocity_states_[i];
+                if (i < velocity_cmds_.size()) {
+                    velocity_cmds_[i] = velocity_states_[i];
+                }
             }
         }
         
@@ -357,6 +365,9 @@ namespace uf_robot_hardware
 
             if (!initialized_) {
                 for (uint i = 0; i < position_states_.size(); i++) {
+                    if (i >= position_cmds_.size() || i >= velocity_cmds_.size()) {
+                        break;
+                    }
                     position_cmds_[i] = position_states_[i];
                     velocity_cmds_[i] = 0.0;
                 }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

add_gripperの変数によるvector sizeを可変にした変更により、
gripper使用時にcommandのvector sizeは小さくなるものの、代入はstateの大きいままのvector sizeをもとにfor loopしていたのでout of rangeがおそらく発生していた。
おそらくこれで解決すると思うが他にもあるかもしれません。

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- ref https://github.com/sbgisen/soar/issues/699

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
